### PR TITLE
Update PKGBUILD to avoid re-build during check()

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,7 +38,7 @@ build() {
 check() {
 	cd "$pkgname-$pkgver"
 	export RUSTUP_TOOLCHAIN=stable
-	cargo test --frozen --all-features
+	cargo test --frozen --release --all-features
 }
 
 package() {


### PR DESCRIPTION
This change avoids re-building the project as a debug build during the check() step, effectively roughly halving the install time.